### PR TITLE
Amend example to use 7.2 Routing service

### DIFF
--- a/map-with-truck-route-from-a-to-b/js/app.js
+++ b/map-with-truck-route-from-a-to-b/js/app.js
@@ -10,7 +10,7 @@
  * @param   {H.service.Platform} platform    A stub class to access HERE services
  */
 function calculateRouteFromAtoB (platform) {
-  var router = platform.getEnterpriseRoutingService(),
+  var router = platform.getRoutingService(),
     routeRequestParams = {
       mode: 'fastest;truck',
       representation: 'display',


### PR DESCRIPTION
Remove reference to 6.2 Routing API as part of https://github.com/heremaps/examples/issues/10