### PR TITLE
Add links to markers-on-the-map

### DIFF
--- a/markers-on-the-map/demo.html
+++ b/markers-on-the-map/demo.html
@@ -21,11 +21,16 @@
         <h1>Marker on the Map</h1>
         <p>Display a map highlighting points of interest</p>
     </div>
-    <p>This example displays a moveable map of <b>Europe</b>, including markers highlighting the locations of the captials of <b>France</b>, <b>Italy</b>, <b>Germany</b>, <b>Spain</b> and the <b>United Kingdom</b>.</p>
+    <p>This example displays a moveable map of <b>Europe</b>, including markers highlighting the locations of the capitals of <b>France</b>, <b>Italy</b>, <b>Germany</b>, <b>Spain</b> and the <b>United Kingdom</b>.</p>
     <div id="map"></div>
     <h3>Code</h3>
     <p>
         Default markers are created by using the <code>H.map.Marker</code> class without specifying an <code>icon</code> and passing in a location only.<br>
+        For more information on markers and ways to customize them, refer to the following documents:
+        <ul>
+          <li><a href="https://www.here.com/docs/bundle/maps-api-for-javascript-developer-guide/page/topics/marker-objects.html" target="_blank">Marker objects</a></li>
+          <li><a href="https://www.here.com/docs/bundle/maps-api-for-javascript-api-reference/page/H.map.Marker.html" target="_blank">H.map.Marker</a></li>
+        </ul>
     </p>
     <script type="text/javascript" src='demo.js'></script>
   </body>


### PR DESCRIPTION
Added links to Dev Guide and API Reference in the [Marker on the Map](https://developer.here.com/documentation/examples/maps-js/markers/markers-on-the-map) article for users to facilitate getting more information on marker customization.